### PR TITLE
feat: add heading_correction as output

### DIFF
--- a/src/Radar.cpp
+++ b/src/Radar.cpp
@@ -29,6 +29,7 @@ void Radar::addEcho(float range,
     uint16_t sweep_length,
     Angle step_angle,
     Angle heading,
+    Angle heading_correction,
     uint8_t* echo_data)
 {
     if (timestamp.isNull()) {
@@ -62,6 +63,7 @@ void Radar::addEcho(float range,
         }
     }
     sweep_timestamps.push_back(Time::now());
+    step_heading_correction.push_back(heading_correction);
     sweep_data.insert(sweep_data.end(), echo_data, echo_data + sweep_length);
 }
 

--- a/src/Radar.hpp
+++ b/src/Radar.hpp
@@ -14,6 +14,7 @@ namespace radar_base {
         base::Angle start_heading = base::Angle::unknown();
         base::Time timestamp;
         std::vector<base::Time> sweep_timestamps;
+        std::vector<base::Angle> step_heading_correction;
         std::vector<uint8_t> sweep_data;
 
         Radar();
@@ -31,6 +32,7 @@ namespace radar_base {
             uint16_t sweep_length,
             base::Angle step_angle,
             base::Angle heading,
+            base::Angle heading_correction,
             uint8_t* echo_data);
     };
 } // namespaces

--- a/test/test_Radar.cpp
+++ b/test/test_Radar.cpp
@@ -15,16 +15,17 @@ struct RadarTest : public ::testing::Test {
     base::Angle heading_0 = base::Angle::fromRad(2.75196);
     base::Angle heading_1 = base::Angle::fromRad(2.7535);
     base::Angle heading_2 = base::Angle::fromRad(2.75503);
+    base::Angle heading_correction = base::Angle::fromRad(0);
 };
 
 TEST_F(RadarTest, it_creates_an_object_correctly)
 {
     ASSERT_EQ(radar.verifyNextAngle(heading_0), true);
-    radar.addEcho(range, sweep_length, step_size, heading_0, echo);
+    radar.addEcho(range, sweep_length, step_size, heading_0, heading_correction, echo);
     ASSERT_EQ(radar.verifyNextAngle(heading_1), true);
-    radar.addEcho(range, sweep_length, step_size, heading_1, echo);
+    radar.addEcho(range, sweep_length, step_size, heading_1, heading_correction, echo);
     ASSERT_EQ(radar.verifyNextAngle(heading_2), true);
-    radar.addEcho(range, sweep_length, step_size, heading_2, echo);
+    radar.addEcho(range, sweep_length, step_size, heading_2, heading_correction, echo);
     uint8_t echo_result[3 * sizeof(echo)];
     memcpy(echo_result, echo, sizeof(echo));
     memcpy(echo_result + sizeof(echo), echo, sizeof(echo));
@@ -42,22 +43,37 @@ TEST_F(RadarTest, it_creates_an_object_correctly)
 TEST_F(RadarTest, it_crashes_with_different_step_size)
 {
     base::Angle step_size2 = base::Angle::fromRad((1.0 / 8192.0) * 2 * M_PI);
-    radar.addEcho(range, sweep_length, step_size, heading_0, echo);
-    ASSERT_THROW(radar.addEcho(range, sweep_length, step_size2, heading_1, echo),
+    radar.addEcho(range, sweep_length, step_size, heading_0, heading_correction, echo);
+    ASSERT_THROW(radar.addEcho(range,
+                     sweep_length,
+                     step_size2,
+                     heading_1,
+                     heading_correction,
+                     echo),
         std::runtime_error);
 }
 
 TEST_F(RadarTest, it_crashes_with_different_sweep_length)
 {
-    radar.addEcho(range, sweep_length, step_size, heading_0, echo);
-    ASSERT_THROW(radar.addEcho(range, sweep_length + 2, step_size, heading_1, echo),
+    radar.addEcho(range, sweep_length, step_size, heading_0, heading_correction, echo);
+    ASSERT_THROW(radar.addEcho(range,
+                     sweep_length + 2,
+                     step_size,
+                     heading_1,
+                     heading_correction,
+                     echo),
         std::runtime_error);
 }
 
 TEST_F(RadarTest, it_crashes_with_different_range)
 {
-    radar.addEcho(range, sweep_length, step_size, heading_0, echo);
-    ASSERT_THROW(radar.addEcho(range + 2.0, sweep_length, step_size, heading_1, echo),
+    radar.addEcho(range, sweep_length, step_size, heading_0, heading_correction, echo);
+    ASSERT_THROW(radar.addEcho(range + 2.0,
+                     sweep_length,
+                     step_size,
+                     heading_1,
+                     heading_correction,
+                     echo),
         std::runtime_error);
 }
 
@@ -72,18 +88,23 @@ TEST_F(RadarTest,
 {
     Radar new_radar;
     ASSERT_EQ(new_radar.verifyNextAngle(heading_0), true);
-    new_radar.addEcho(range, sweep_length, step_size, heading_0, echo);
+    new_radar
+        .addEcho(range, sweep_length, step_size, heading_0, heading_correction, echo);
     ASSERT_EQ(new_radar.verifyNextAngle(heading_1), true);
-    new_radar.addEcho(range, sweep_length, step_size, heading_1, echo);
+    new_radar
+        .addEcho(range, sweep_length, step_size, heading_1, heading_correction, echo);
 }
 TEST_F(RadarTest,
     it_crashes_if_the_angle_is_not_within_size_times_step_from_the_first_with_a_positive_step_angle)
 {
     Radar new_radar;
     ASSERT_EQ(new_radar.verifyNextAngle(heading_0), true);
-    new_radar.addEcho(range, sweep_length, step_size, heading_0, echo);
+    new_radar
+        .addEcho(range, sweep_length, step_size, heading_0, heading_correction, echo);
     ASSERT_EQ(new_radar.verifyNextAngle(heading_2), false);
-    ASSERT_THROW(new_radar.addEcho(range, sweep_length, step_size, heading_2, echo),
+    ASSERT_THROW(
+        new_radar
+            .addEcho(range, sweep_length, step_size, heading_2, heading_correction, echo),
         std::runtime_error);
 }
 
@@ -96,12 +117,14 @@ TEST_F(RadarTest,
         sweep_length,
         base::Angle::fromRad(-step_size.getRad()),
         heading_0,
+        heading_correction,
         echo);
     ASSERT_EQ(new_radar.verifyNextAngle(heading_n1), true);
     new_radar.addEcho(range,
         sweep_length,
         base::Angle::fromRad(-step_size.getRad()),
         heading_n1,
+        heading_correction,
         echo);
 }
 
@@ -114,12 +137,14 @@ TEST_F(RadarTest,
         sweep_length,
         base::Angle::fromRad(-step_size.getRad()),
         heading_0,
+        heading_correction,
         echo);
     ASSERT_EQ(new_radar.verifyNextAngle(heading_n2), false);
     ASSERT_THROW(new_radar.addEcho(range,
                      sweep_length,
                      base::Angle::fromRad(-step_size.getRad()),
                      heading_n2,
+                     heading_correction,
                      echo),
         std::runtime_error);
 }


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-orogen-radar_furuno_dstnxt/pull/12

# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
We are experiencing some yaw rotation on radar measurements when tupan rotates in yaw axis. I believe there is something to do with an output we are not tracking, the heading. Basically on the radar echo callback, there are two variables related to the position of the sensor: angle and heading. Both are values from 0 to 8192, the first one indicates the position of the antena. The second variable corresponds to a correction so the 0 corresponds to forward.
According to the documentation, this correction uses nmea heading as input, we do not provide this heading. Maybe there is still something on the SDK correcting the measurement and this is messing the output. 

This PR allows us to keep track of this variable.
 
# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [x] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
