### PR TITLE
feat: create a way to forcefully write values into the image

### DIFF
--- a/src/EchoToImageLUT.cpp
+++ b/src/EchoToImageLUT.cpp
@@ -97,7 +97,11 @@ void EchoToImageLUT::addRawLUTEntry(RawTable& table,
     table[angle * sweep_size + echo_index].push_back(p);
 }
 
-void EchoToImageLUT::updateImage(Mat& image, int angle, int echo_index, int echo) const
+void EchoToImageLUT::updateImage(Mat& image,
+    int angle,
+    int echo_index,
+    int echo,
+    bool force_write) const
 {
     if (echo < 0) {
         echo = 0;
@@ -109,7 +113,8 @@ void EchoToImageLUT::updateImage(Mat& image, int angle, int echo_index, int echo
         auto p = m_data[id];
 
         auto& current = image.at<Vec3b>(p);
-        auto v = std::max<int>(current[0], echo);
+
+        auto v = force_write ? echo : std::max<int>(current[0], echo);
         current = Vec3b(v, v, v);
     }
 }

--- a/src/EchoToImageLUT.hpp
+++ b/src/EchoToImageLUT.hpp
@@ -44,7 +44,11 @@ namespace radar_base {
         EchoToImageLUT(int num_angles, int sweep_size, float beam_width, int window_size);
         ~EchoToImageLUT() = default;
 
-        void updateImage(cv::Mat& image, int angle, int echo_index, int echo) const;
+        void updateImage(cv::Mat& image,
+            int angle,
+            int echo_index,
+            int echo,
+            bool force_write = false) const;
 
         void linearizeRawTable(RawTable const& table);
 


### PR DESCRIPTION
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

When using this function for the an internal tool GUI, we needed to be able to write on the image one echo at a time. To do so, the newest echo must overwrite the image's value of the oldest echo. Therefore we needed to create this variable, to allow write one echo at a time.

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
