### PR TITLE
chore: helper functions for radar visualization in the radar_base library

### DIFF
--- a/src/EchoToImageLUT.cpp
+++ b/src/EchoToImageLUT.cpp
@@ -127,9 +127,6 @@ void EchoToImageLUT::drawImageFromEchoes(std::vector<uint8_t> const& world_echoe
     cv::Mat& radar_frame)
 {
     for (long i = 0; i < static_cast<long>(world_echoes.size()); i++) {
-        updateImage(radar_frame,
-            i / m_sweep_size,
-            i % m_sweep_size,
-            world_echoes.at(i));
+        updateImage(radar_frame, i / m_sweep_size, i % m_sweep_size, world_echoes.at(i));
     }
 }

--- a/src/EchoToImageLUT.cpp
+++ b/src/EchoToImageLUT.cpp
@@ -6,7 +6,7 @@ using namespace radar_base;
 using namespace cv;
 using namespace std;
 
-int discretizeAngle(double theta_rad, int num_angles)
+static int discretizeAngle(double theta_rad, int num_angles)
 {
     double angle_step = 2 * M_PI / num_angles;
     return round(theta_rad / angle_step);
@@ -17,18 +17,12 @@ EchoToImageLUT::EchoToImageLUT(int num_angles,
     float beam_width,
     int window_size)
     : m_sweep_size(sweep_size)
-{
-    setup(sweep_size, window_size, num_angles, beam_width);
-}
-
-void EchoToImageLUT::setup(int sweep_size,
-    int window_size,
-    int num_angles,
-    float beam_width)
+    , m_num_angles(num_angles)
+    , m_beam_width(beam_width)
+    , m_window_size(window_size)
 {
     auto raw_data = computeRawLUTTable(sweep_size, window_size, num_angles, beam_width);
     linearizeRawTable(raw_data);
-    m_sweep_size = sweep_size;
 }
 
 vector<vector<Point>> EchoToImageLUT::computeRawLUTTable(int sweep_size,
@@ -97,11 +91,7 @@ void EchoToImageLUT::addRawLUTEntry(RawTable& table,
     table[angle * sweep_size + echo_index].push_back(p);
 }
 
-void EchoToImageLUT::updateImage(Mat& image,
-    int angle,
-    int echo_index,
-    int echo,
-    bool force_write) const
+void EchoToImageLUT::updateImage(Mat& image, int angle, int echo_index, int echo) const
 {
     if (echo < 0) {
         echo = 0;
@@ -113,8 +103,7 @@ void EchoToImageLUT::updateImage(Mat& image,
         auto p = m_data[id];
 
         auto& current = image.at<Vec3b>(p);
-
-        auto v = force_write ? echo : std::max<int>(current[0], echo);
+        auto v = std::max<int>(current[0], echo);
         current = Vec3b(v, v, v);
     }
 }
@@ -123,4 +112,24 @@ Point EchoToImageLUT::fetchEntry(int angle, int echo_index_in_sweep) const
 {
     auto data_i = angle * m_sweep_size + echo_index_in_sweep;
     return m_data[m_data_index[data_i]];
+}
+
+bool EchoToImageLUT::hasMatchingConfiguration(int num_angles,
+    int sweep_size,
+    float beam_width,
+    int window_size)
+{
+    return num_angles == m_num_angles && sweep_size == m_sweep_size &&
+           beam_width == m_beam_width && window_size == m_window_size;
+}
+
+void EchoToImageLUT::drawImageFromEchoes(std::vector<uint8_t> const& world_echoes,
+    cv::Mat& radar_frame)
+{
+    for (long i = 0; i < static_cast<long>(world_echoes.size()); i++) {
+        updateImage(radar_frame,
+            i / m_sweep_size,
+            i % m_sweep_size,
+            world_echoes.at(i));
+    }
 }

--- a/src/EchoToImageLUT.hpp
+++ b/src/EchoToImageLUT.hpp
@@ -50,7 +50,7 @@ namespace radar_base {
         /**
          * Checks if provided configuration matches the LUT.
          *
-         * @param num_angles Amount of samples contained in a radar revolution.
+         * @param num_angles Amount of sweeps contained in a radar revolution.
          * @param sweep_size Number of measurements inside a single sweep.
          * @param beam_width Angle between the 3dB half power points on the main lobe.
          * @param window_size The param will create a squared frame.
@@ -67,8 +67,6 @@ namespace radar_base {
          * Draws image based on a vector representing the full rotation of the radar.
          *
          * @param world_echoes the vector representing a full radar rotation
-         * @param radar_sweep_size the radar sweep size
-         * @param lut the echo to image look up table
          * @param radar_frame the frame where the radar will be drawn in
          */
         void drawImageFromEchoes(std::vector<uint8_t> const& world_echoes,

--- a/src/EchoToImageLUT.hpp
+++ b/src/EchoToImageLUT.hpp
@@ -13,6 +13,9 @@ namespace radar_base {
         std::vector<int> m_data_index;
 
         int m_sweep_size;
+        int m_num_angles;
+        float m_beam_width;
+        int m_window_size;
 
         static int normalizeAngle(int angle, int num_angles);
 
@@ -28,8 +31,6 @@ namespace radar_base {
             int num_angles,
             cv::Point2i const& p);
 
-        void setup(int sweep_size, int window_size, int num_angles, float beam_width);
-
     public:
         EchoToImageLUT() = delete;
 
@@ -44,13 +45,34 @@ namespace radar_base {
         EchoToImageLUT(int num_angles, int sweep_size, float beam_width, int window_size);
         ~EchoToImageLUT() = default;
 
-        void updateImage(cv::Mat& image,
-            int angle,
-            int echo_index,
-            int echo,
-            bool force_write = false) const;
+        void updateImage(cv::Mat& image, int angle, int echo_index, int echo) const;
+
+        /**
+         * Checks if provided configuration matches the LUT.
+         *
+         * @param num_angles Amount of samples contained in a radar revolution.
+         * @param sweep_size Number of measurements inside a single sweep.
+         * @param beam_width Angle between the 3dB half power points on the main lobe.
+         * @param window_size The param will create a squared frame.
+         * @return whether the LUT configuration matches the given parameters
+         */
+        bool hasMatchingConfiguration(int num_angles,
+            int sweep_size,
+            float beam_width,
+            int window_size);
 
         void linearizeRawTable(RawTable const& table);
+
+        /**
+         * Draws image based on a vector representing the full rotation of the radar.
+         *
+         * @param world_echoes the vector representing a full radar rotation
+         * @param radar_sweep_size the radar sweep size
+         * @param lut the echo to image look up table
+         * @param radar_frame the frame where the radar will be drawn in
+         */
+        void drawImageFromEchoes(std::vector<uint8_t> const& world_echoes,
+            cv::Mat& radar_frame);
 
         cv::Point fetchEntry(int angle, int echo_index) const;
     };

--- a/src/Radar.hpp
+++ b/src/Radar.hpp
@@ -39,7 +39,7 @@ namespace radar_base {
          *
          * @param radar_echo the current radar echo to be saved
          * @param yaw_correction the yaw correction to be applied into this radar echo
-         * @param world_echoes the vector representing a full radar rotation to be updated
+         * @param world_echoes the serialized full radar rotation to be updated
          */
         static void updateEchoes(Radar const& radar_echo,
             base::Angle const& yaw_correction,

--- a/src/Radar.hpp
+++ b/src/Radar.hpp
@@ -32,6 +32,18 @@ namespace radar_base {
             base::Angle step_angle,
             base::Angle heading,
             uint8_t* echo_data);
+
+        /**
+         * Iterates over the sweeps of a radar echo saving them into the world echoes
+         * vector.
+         *
+         * @param radar_echo the current radar echo to be saved
+         * @param yaw_correction the yaw correction to be applied into this radar echo
+         * @param world_echoes the vector representing a full radar rotation to be updated
+         */
+        static void updateEchoes(Radar const& radar_echo,
+            base::Angle const& yaw_correction,
+            std::vector<uint8_t>& world_echoes);
     };
 } // namespaces
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/perception-usv_obstacle_fusion/pull/96

# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

This is done as the fusion library uses the same code as the radar_base orogen, so to avoid code repetition, these functions are included here in radar_base.

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
