### PR TITLE
rafactor: rename timestamp field to time

### DIFF
--- a/src/Radar.cpp
+++ b/src/Radar.cpp
@@ -17,7 +17,7 @@ Radar::Radar(float range,
     , sweep_length(sweep_length)
     , step_angle(step_angle)
     , start_heading(start_heading)
-    , timestamp(timestamp)
+    , time(timestamp)
 {
 }
 
@@ -31,8 +31,8 @@ void Radar::addEcho(float range,
     Angle heading,
     uint8_t* echo_data)
 {
-    if (timestamp.isNull()) {
-        timestamp = Time::now();
+    if (time.isNull()) {
+        time = Time::now();
         this->range = range;
         this->sweep_length = sweep_length;
         this->step_angle = step_angle;
@@ -67,7 +67,7 @@ void Radar::addEcho(float range,
 
 bool Radar::verifyNextAngle(Angle angle)
 {
-    if (timestamp.isNull()) {
+    if (time.isNull()) {
         return true;
     }
     Angle expected = start_heading + step_angle * (sweep_timestamps.size());

--- a/src/Radar.hpp
+++ b/src/Radar.hpp
@@ -12,7 +12,7 @@ namespace radar_base {
         uint16_t sweep_length = base::unknown<uint16_t>();
         base::Angle step_angle = base::Angle::unknown();
         base::Angle start_heading = base::Angle::unknown();
-        base::Time timestamp;
+        base::Time time;
         std::vector<base::Time> sweep_timestamps;
         std::vector<uint8_t> sweep_data;
 
@@ -22,7 +22,7 @@ namespace radar_base {
             uint16_t sweep_length,
             base::Angle step_angle,
             base::Angle start_heading,
-            base::Time timestamp);
+            base::Time time);
 
         ~Radar();
         bool verifyNextAngle(base::Angle angle);


### PR DESCRIPTION

Depends on:
- [ ] https://github.com/tidewise/drivers-orogen-radar_base/pull/8


# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
[sc-43802]
- [ ] [Shortcut](http://) -->
This refactor is being necessary for using the Radar type within orogen's stream aligner
# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
