### PR TITLE
fix: return indexes instead iterators

### DIFF
--- a/src/EchoToImageLUT.cpp
+++ b/src/EchoToImageLUT.cpp
@@ -131,11 +131,10 @@ void EchoToImageLUT::drawImageFromEchoes(std::vector<uint8_t> const& world_echoe
     }
 }
 
-pair<vector<Point>::const_iterator, vector<Point>::const_iterator> EchoToImageLUT::
-    getPixels(int angle_idx, int sweep_idx) const
+pair<size_t, size_t> EchoToImageLUT::getPixels(int angle_idx, int sweep_idx) const
 {
-    int initial_point_idx = m_data_index[angle_idx * m_sweep_size + sweep_idx];
-    int final_point_idx = m_data_index[angle_idx * m_sweep_size + sweep_idx + 1] - 1;
-    return std::make_pair(m_data.cbegin() + initial_point_idx,
-        m_data.cbegin() + final_point_idx);
+    size_t initial_point_idx = m_data_index[angle_idx * m_sweep_size + sweep_idx];
+    size_t final_point_idx = m_data_index[angle_idx * m_sweep_size + sweep_idx + 1] - 1;
+    return std::make_pair(initial_point_idx, final_point_idx);
+}
 }

--- a/src/EchoToImageLUT.cpp
+++ b/src/EchoToImageLUT.cpp
@@ -137,4 +137,8 @@ pair<size_t, size_t> EchoToImageLUT::getPixels(int angle_idx, int sweep_idx) con
     size_t final_point_idx = m_data_index[angle_idx * m_sweep_size + sweep_idx + 1] - 1;
     return std::make_pair(initial_point_idx, final_point_idx);
 }
+
+std::vector<cv::Point> EchoToImageLUT::getLUT()
+{
+    return m_data;
 }

--- a/src/EchoToImageLUT.hpp
+++ b/src/EchoToImageLUT.hpp
@@ -43,9 +43,7 @@ namespace radar_base {
          * @return std::pair<std::vector<cv::Point>::const_iterator,
          * std::vector<cv::Point>::const_iterator>
          */
-        std::pair<std::vector<cv::Point>::const_iterator,
-            std::vector<cv::Point>::const_iterator>
-        getPixels(int angle_idx, int sweep_idx) const;
+        std::pair<size_t, size_t> getPixels(int angle_idx, int sweep_idx) const;
         /**
          * Constructor that creates a LUT matrix based on radar echoes.
          * @brief Constructor.

--- a/src/EchoToImageLUT.hpp
+++ b/src/EchoToImageLUT.hpp
@@ -45,6 +45,12 @@ namespace radar_base {
          */
         std::pair<size_t, size_t> getPixels(int angle_idx, int sweep_idx) const;
         /**
+         * @brief Returns the echoes to image look-up table
+         *
+         * @return std::vector<cv::Point>
+         */
+        std::vector<cv::Point> getLUT();
+        /**
          * Constructor that creates a LUT matrix based on radar echoes.
          * @brief Constructor.
          * @param num_angles Amount of samples contained in a radar revolution.

--- a/test/test_EchoToImageLUT.cpp
+++ b/test/test_EchoToImageLUT.cpp
@@ -9,14 +9,16 @@ struct EchoToImageTest : public ::testing::Test {
     int sweep_size = 2;
     float beam_width = M_PI / 2;
     int window_size = 3;
-    EchoToImageLUT lut = EchoToImageLUT(num_angles, sweep_size, beam_width, window_size);
+    EchoToImageLUT lut_class =
+        EchoToImageLUT(num_angles, sweep_size, beam_width, window_size);
 };
 
-TEST_F(EchoToImageTest, it_returns_the_initial_and_final_pixel_iterators_for_a_radar_dot)
+TEST_F(EchoToImageTest, it_returns_the_initial_and_final_pixel_index_for_a_radar_dot)
 {
-    auto iterators = lut.getPixels(0, 1);
-    ASSERT_EQ(iterators.first->x, 1);
-    ASSERT_EQ(iterators.first->y, 0);
-    ASSERT_EQ(iterators.second->x, 2);
-    ASSERT_EQ(iterators.second->y, 1);
+    auto indexes = lut_class.getPixels(0, 1);
+    auto lut = lut_class.getLUT();
+    ASSERT_EQ(lut[indexes.first].x, 1);
+    ASSERT_EQ(lut[indexes.first].y, 0);
+    ASSERT_EQ(lut[indexes.first].x, 2);
+    ASSERT_EQ(lut[indexes.first].y, 1);
 }


### PR DESCRIPTION
# What is this PR for
fix: return indexes instead iterators
feat: add method to return the echoes to image lut

# Motivation
The iteration over the LUT was occurring wrongly as one can see in the following pictures, where the loop should occur between the indexes.first (256, 256) and the index.second (256,255). So I decided to get the LUT at the usv_radar_simulation, and iterate over the lut there.

The LUT:
![lut](https://github.com/tidewise/drivers-radar_base/assets/80434858/9d9b29d4-2fcb-4753-8f77-627b566247ea)

The iteration:
![iteration](https://github.com/tidewise/drivers-radar_base/assets/80434858/ffab0387-2f52-4153-8aa3-13acfa65b923)


# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)