### PR TITLE
fix: get pixels method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(radar_base
         DESCRIPTION "Common implementation for Radar management")
 find_package(Rock)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 rock_init()

--- a/src/EchoToImageLUT.cpp
+++ b/src/EchoToImageLUT.cpp
@@ -96,13 +96,9 @@ void EchoToImageLUT::updateImage(Mat& image, int angle, int echo_index, int echo
     if (echo < 0) {
         echo = 0;
     }
-    int data_i = angle * m_sweep_size + echo_index;
-    auto begin = m_data_index[data_i];
-    auto end = m_data_index[data_i + 1];
-    for (auto id = begin; id < end; id++) {
-        auto p = m_data[id];
-
-        auto& current = image.at<Vec3b>(p);
+    auto its = getPixels(angle, echo_index);
+    for (auto [pixel, last_pixel] = its; pixel != last_pixel; pixel++) {
+        auto& current = image.at<Vec3b>(*pixel);
         auto v = std::max<int>(current[0], echo);
         current = Vec3b(v, v, v);
     }
@@ -132,9 +128,9 @@ void EchoToImageLUT::drawImageFromEchoes(std::vector<uint8_t> const& world_echoe
 }
 
 pair<vector<Point>::const_iterator, vector<Point>::const_iterator> EchoToImageLUT::
-    getPixels(int angle_idx, int sweep_idx) const
+    getPixels(int angle_idx, int cell_idx) const
 {
-    int pixels_begin = m_data_index[angle_idx * m_sweep_size + sweep_idx];
-    int pixels_end = m_data_index[angle_idx * m_sweep_size + sweep_idx + 1];
+    int pixels_begin = m_data_index[angle_idx * m_sweep_size + cell_idx];
+    int pixels_end = m_data_index[angle_idx * m_sweep_size + cell_idx + 1];
     return std::make_pair(m_data.cbegin() + pixels_begin, m_data.cbegin() + pixels_end);
 }

--- a/src/EchoToImageLUT.cpp
+++ b/src/EchoToImageLUT.cpp
@@ -134,8 +134,7 @@ void EchoToImageLUT::drawImageFromEchoes(std::vector<uint8_t> const& world_echoe
 pair<vector<Point>::const_iterator, vector<Point>::const_iterator> EchoToImageLUT::
     getPixels(int angle_idx, int sweep_idx) const
 {
-    int initial_point_idx = m_data_index[angle_idx * m_sweep_size + sweep_idx];
-    int final_point_idx = m_data_index[angle_idx * m_sweep_size + sweep_idx + 1] - 1;
-    return std::make_pair(m_data.cbegin() + initial_point_idx,
-        m_data.cbegin() + final_point_idx);
+    int pixels_begin = m_data_index[angle_idx * m_sweep_size + sweep_idx];
+    int pixels_end = m_data_index[angle_idx * m_sweep_size + sweep_idx + 1];
+    return std::make_pair(m_data.cbegin() + pixels_begin, m_data.cbegin() + pixels_end);
 }

--- a/src/EchoToImageLUT.hpp
+++ b/src/EchoToImageLUT.hpp
@@ -34,9 +34,10 @@ namespace radar_base {
     public:
         EchoToImageLUT() = delete;
         /**
-         * @brief Returns a pair of iterators pointing to the initial and the final pixel
-         * in a radar echo dot represented by an angle index and a sweep index at the
-         * echoes to image look-up table
+         * @brief Returns a pair of constant iterators defining a range of pixels in a
+         * radar echo dot, determined by an angle index and a sweep index, at the echoes
+         * to image look-up table
+         *
          *
          * @param angle_idx The angle index
          * @param sweep_idx The sweep index

--- a/src/EchoToImageLUT.hpp
+++ b/src/EchoToImageLUT.hpp
@@ -35,12 +35,12 @@ namespace radar_base {
         EchoToImageLUT() = delete;
         /**
          * @brief Returns a pair of constant iterators defining a range of pixels in a
-         * radar echo dot, determined by an angle index and a sweep index, at the echoes
+         * radar echo dot, determined by an angle index and a cell index, at the echoes
          * to image look-up table
          *
          *
          * @param angle_idx The angle index
-         * @param sweep_idx The sweep index
+         * @param cell_idx The cell index
          * @return std::pair<std::vector<cv::Point>::const_iterator,
          * std::vector<cv::Point>::const_iterator>
          */

--- a/test/test_EchoToImageLUT.cpp
+++ b/test/test_EchoToImageLUT.cpp
@@ -1,8 +1,6 @@
 #include <gtest/gtest.h>
 #include <radar_base/EchoToImageLUT.hpp>
 
-#include <iostream>
-
 using namespace radar_base;
 using namespace std;
 

--- a/test/test_EchoToImageLUT.cpp
+++ b/test/test_EchoToImageLUT.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include <radar_base/EchoToImageLUT.hpp>
 
+#include <iostream>
+
 using namespace radar_base;
 using namespace std;
 
@@ -17,6 +19,6 @@ TEST_F(EchoToImageTest, it_returns_the_initial_and_final_pixel_iterators_for_a_r
     auto iterators = lut.getPixels(0, 1);
     ASSERT_EQ(iterators.first->x, 1);
     ASSERT_EQ(iterators.first->y, 0);
-    ASSERT_EQ(iterators.second->x, 2);
+    ASSERT_EQ(iterators.second->x, 1);
     ASSERT_EQ(iterators.second->y, 1);
 }


### PR DESCRIPTION
# What is this PR for
[sc-46514]
fix: fix the get pixels method
The second element of the pair was pointing to the last element in the radar echo dot, not to the end of the range

chore: use the get pixels method inside the update image

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)